### PR TITLE
examples: Add warning to README

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,1 +1,5 @@
+> [!WARNING]
+> The profiles in this directory are kept as a public archive!
+> They are not guaranteed to work with the latest ncov workflow.
+
 These files have been migrated from [``ncov/my_profiles/``](https://github.com/nextstrain/ncov/blob/c900acab21d61a65e4ac161d63411a748d3858e8/my_profiles).


### PR DESCRIPTION
Instead of keeping these profiles up-to-date indefinitely, clearly warn that  they are public archives that are not guaranteed to work.

Resolves https://github.com/nextstrain/ncov-tutorial/issues/3.